### PR TITLE
Fixed: kubeconfig ip replacement failure on macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.lock.hcl
 *.tfstate*
 tfplan
+kubeconfig-*.yaml
+.vscode


### PR DESCRIPTION
Fixed
- Kubeconfig IP replacement failure on macOS due to sed compatibility issues
- Switched to awk for cross-platform compatibility

Tested
- Verified on both macOS and Linux environments